### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,22 +4,22 @@
 # Class
 #######################################
 
-Nextion KEYWORD1 Nextion
+Nextion	KEYWORD1 Nextion
 
 #######################################
 # Methods and Functions 
 #######################################	
 
 buttonToggleEvent	KEYWORD2
-buttonOnOff		KEYWORD2
+buttonOnOff	KEYWORD2
 setComponentValue	KEYWORD2
-ack					KEYWORD2
+ack	KEYWORD2
 getComponentValue	KEYWORD2
 setComponentText	KEYWORD2
-listen			KEYWORD2
-sendCommand		KEYWORD2
-init			KEYWORD2
-flushSerial		KEYWORD2
+listen	KEYWORD2
+sendCommand	KEYWORD2
+init	KEYWORD2
+flushSerial	KEYWORD2
 
 #######################################
 # Constants


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords